### PR TITLE
# feat: QuickNaviaget

### DIFF
--- a/contrib/QuickNavigate.popclipext/Config.yaml
+++ b/contrib/QuickNavigate.popclipext/Config.yaml
@@ -1,0 +1,29 @@
+#popclip
+name: Quick Navigate
+identifier: com.quicknavigate.popclip
+description: Navigate to preset websites with selected text. Click to choose from your configured URLs.
+version: 1.0
+author: Yimin Wang
+icon: symbol:arrow.up.forward.circle.fill
+popclip version: 4688
+shell script file: quicknavigate.sh
+interpreter: /bin/bash
+options:
+  - identifier: config_file_path
+    label: Configuration File Path
+    type: string
+    description: Path to JSON config file. E.g. ~/Documents/quicknavigate-config.json or ~/Library/Mobile Documents/com~apple~CloudDocs/quicknavigate-config.json for iCloud sync.
+  
+  - identifier: browser
+    label: Browser
+    type: multiple
+    values: [Safari, Google Chrome, Microsoft Edge, Firefox, Arc, Brave Browser, Opera]
+    value labels: [Safari, Chrome, Edge, Firefox, Arc, Brave, Opera]
+    default value: Safari
+    description: Browser to open URLs in
+
+  - identifier: skip_dialog
+    label: Skip Selection Dialog
+    type: boolean
+    description: If enabled, always use the first configuration without showing selection dialog.
+

--- a/contrib/QuickNavigate.popclipext/QUICKSTART.md
+++ b/contrib/QuickNavigate.popclipext/QUICKSTART.md
@@ -1,0 +1,200 @@
+# Quick Navigate - 快速开始指南
+
+## 30秒快速配置
+
+### 1️⃣ 创建配置文件
+
+创建文件 `~/Documents/quicknavigate-config.json`：
+
+```json
+[
+  {
+    "name": "谷歌搜索",
+    "url": "https://www.google.com/search?q={text}",
+    "description": "在 Google 搜索"
+  },
+  {
+    "name": "Grafana日志",
+    "url": "https://plan-dev-grafana.api.brain.ai/explore?schemaVersion=1&panes={\"97l\":{\"datasource\":\"P8E80F9AEF21F6940\",\"queries\":[{\"refId\":\"A\",\"expr\":\"{app=\\\"planning-api\\\"} |= `{text}`\",\"queryType\":\"range\",\"datasource\":{\"type\":\"loki\",\"uid\":\"P8E80F9AEF21F6940\"},\"editorMode\":\"builder\",\"direction\":\"backward\"}],\"range\":{\"from\":\"now-7d\",\"to\":\"now\"}}}}&orgId=1",
+    "description": "搜索 planning-api 日志（最近7天）"
+  }
+]
+```
+
+💡 **提示**：URL 现在使用**人类可读格式**，无需手动编码！你可以直接从浏览器复制 URL，只需将搜索文本替换为 `{text}` 即可。
+
+### 2️⃣ 配置插件
+
+1. 打开 PopClip 偏好设置
+2. 找到 Quick Navigate 扩展
+3. 设置 **Configuration File Path**: `~/Documents/quicknavigate-config.json`
+4. 选择你喜欢的浏览器（如 Safari、Chrome 等）
+
+### 3️⃣ 开始使用
+
+**标准使用（显示选择对话框）**
+- 选择文本 "LINEでFraserに3時間前に送信したメッセージを探して"
+- 点击 PopClip 中的 Quick Navigate 图标
+- 从弹出的对话框中选择 "Grafana日志" 或 "谷歌搜索"
+- 自动在选择的网站中搜索这段文本！
+
+**快速模式（跳过对话框）**
+- 在 PopClip 设置中启用 **Skip Selection Dialog**
+- 选择任意文本
+- 点击 Quick Navigate 图标
+- 自动使用第一个配置打开网站（无需选择）
+
+## iCloud 同步配置
+
+### 为什么要用 iCloud 同步？
+
+如果你有多台 Mac，使用 iCloud 同步配置文件可以：
+- ✅ 在所有设备上使用相同的配置
+- ✅ 修改一次，所有设备自动更新
+- ✅ 不用手动复制配置文件
+
+### 如何设置 iCloud 同步？
+
+**步骤 1：创建配置文件在 iCloud**
+
+```bash
+# 在终端执行
+touch ~/Library/Mobile\ Documents/com~apple~CloudDocs/quicknavigate-config.json
+```
+
+**步骤 2：编辑配置文件**
+
+用文本编辑器打开上面创建的文件，粘贴你的配置：
+
+```json
+[
+  {
+    "name": "Grafana日志",
+    "url": "https://your-grafana-url.com/explore?query={text}"
+  }
+]
+```
+
+**步骤 3：在 PopClip 中设置路径**
+
+在 PopClip 的 Quick Navigate 设置中，将 **Configuration File Path** 设置为：
+
+```
+~/Library/Mobile Documents/com~apple~CloudDocs/quicknavigate-config.json
+```
+
+**步骤 4：完成！**
+
+现在你的配置会自动同步到所有启用了 iCloud Drive 的 Mac 上。
+
+## 实用配置示例
+
+### 示例 1：Grafana 日志搜索（人类可读！）
+
+```json
+{
+  "name": "Grafana - Planning API",
+  "url": "https://plan-dev-grafana.api.brain.ai/explore?schemaVersion=1&panes={\"97l\":{\"datasource\":\"P8E80F9AEF21F6940\",\"queries\":[{\"refId\":\"A\",\"expr\":\"{app=\\\"planning-api\\\"} |= `{text}`\",\"queryType\":\"range\",\"datasource\":{\"type\":\"loki\",\"uid\":\"P8E80F9AEF21F6940\"},\"editorMode\":\"builder\",\"direction\":\"backward\"}],\"range\":{\"from\":\"now-7d\",\"to\":\"now\"}}}}&orgId=1",
+  "description": "搜索 planning-api 应用日志（最近7天）"
+}
+```
+
+**参数说明**：
+- `datasource`: Loki 数据源 ID
+- `expr`: 查询表达式 `{app="planning-api"} |= `{text}`` 
+- `range`: 时间范围 `now-7d` = 最近7天
+- `{text}`: 自动替换为你选中的文本
+
+### 示例 2：多语言搜索
+
+```json
+{
+  "name": "DeepL 翻译",
+  "url": "https://www.deepl.com/translator#en/zh/{text}",
+  "description": "英译中自动翻译"
+}
+```
+
+### 示例 3：代码搜索
+
+```json
+{
+  "name": "GitHub 代码搜索",
+  "url": "https://github.com/search?q={text}&type=code",
+  "description": "在 GitHub 仓库中搜索代码"
+}
+```
+
+### 示例 4：内部文档
+
+```json
+{
+  "name": "公司 Wiki",
+  "url": "https://wiki.yourcompany.com/search?q={text}",
+  "description": "在公司内部文档中搜索"
+}
+```
+
+### 配置字段说明
+
+- **name** (必需): 配置的名称
+- **url** (必需): URL 模板，使用 `{text}` 作为占位符
+- **description** (可选): 描述信息，会显示在选择对话框中
+
+## 常见问题
+
+### Q: 文件路径要用什么格式？
+A: 使用以下任意格式：
+- `~/Documents/file.json` （本地文档）
+- `~/Library/Mobile Documents/com~apple~CloudDocs/file.json` （iCloud）
+- `/Users/username/path/to/file.json` （绝对路径）
+
+### Q: 如何在 URL 中使用选中的文本？
+A: 在 URL 模板中使用 `{text}` 或 `***` 作为占位符，例如：
+- `https://example.com/search?q={text}`
+- `https://example.com/query=***`
+
+选中的文本会自动进行 URL 编码后替换占位符。
+
+### Q: 如何跳过选择对话框直接打开？
+A: 在 PopClip 设置中，勾选 **Skip Selection Dialog**。启用后会自动使用配置文件中的第一个配置，不显示选择对话框。如果你主要使用一个配置，把它放在 JSON 数组的第一个位置即可。
+
+### Q: 配置文件找不到？
+A: 检查以下几点：
+1. 文件路径是否正确
+2. 文件是否真的存在（使用 Finder 或终端查看）
+3. iCloud Drive 是否已启用
+4. 路径中的 `~` 会自动扩展为你的用户目录
+
+### Q: JSON 格式错误？
+A: 使用在线工具验证 JSON：
+- [jsonlint.com](https://jsonlint.com/)
+- 检查是否缺少逗号、括号、引号
+- 确保每个配置都有 `name` 和 `url` 字段
+
+## 终端命令快速参考
+
+```bash
+# 创建本地配置文件
+touch ~/Documents/quicknavigate-config.json
+open -a TextEdit ~/Documents/quicknavigate-config.json
+
+# 创建 iCloud 配置文件
+touch ~/Library/Mobile\ Documents/com~apple~CloudDocs/quicknavigate-config.json
+open -a TextEdit ~/Library/Mobile\ Documents/com~apple~CloudDocs/quicknavigate-config.json
+
+# 验证 JSON 格式（需要安装 jq）
+cat ~/Documents/quicknavigate-config.json | jq .
+
+# 查看文件是否存在
+ls -la ~/Documents/quicknavigate-config.json
+```
+
+## 下一步
+
+- 📖 查看完整文档：[README.md](README.md)
+- 💡 查看更多配置示例：[example-config.json](example-config.json)
+- 🐛 遇到问题？检查 PopClip 的通知消息获取详细错误信息
+
+祝使用愉快！🎉
+

--- a/contrib/QuickNavigate.popclipext/README.md
+++ b/contrib/QuickNavigate.popclipext/README.md
@@ -1,0 +1,172 @@
+# Quick Navigate
+
+Navigate to preset websites with selected text. Simplified version inspired by JSON Tailor.
+
+## Features
+
+- 🚀 **Quick Navigation**: Select text and choose from your preset websites
+- 📋 **Selection Dialog**: Click to see all your configured URLs and pick one
+- ☁️ **iCloud Sync**: Store your configuration in iCloud Drive for seamless sync across devices
+- 🌐 **Browser Selection**: Choose your preferred browser
+- 📝 **Simple Configuration**: Easy-to-understand JSON configuration format
+- ⚡ **Skip Dialog Option**: Enable to always use the first configuration without dialog
+
+## Installation
+
+1. Double-click the `QuickNavigate.popclipext` package to install
+2. Configure the extension in PopClip preferences
+
+## Configuration
+
+### Step 1: Create Configuration File
+
+Create a JSON file (e.g., `quicknavigate-config.json`) with your navigation targets:
+
+```json
+[
+  {
+    "name": "Google Search",
+    "url": "https://www.google.com/search?q={text}",
+    "description": "在 Google 搜索选中的文本"
+  },
+  {
+    "name": "GitHub Search",
+    "url": "https://github.com/search?q={text}&type=code",
+    "description": "在 GitHub 代码中搜索"
+  },
+  {
+    "name": "Your Custom Site",
+    "url": "https://example.com/search?query={text}",
+    "description": "Optional description shown in selection dialog"
+  }
+]
+```
+
+**Configuration Fields:**
+- `name` (required): Short name for this configuration
+- `url` (required): URL template with `{text}` or `***` placeholder
+- `description` (optional): Helpful description shown in selection dialog
+
+**URL Format:**
+- Use **human-readable URLs** (no need to URL-encode)
+- Use `{text}` or `***` as placeholder for selected text
+- The selected text will be automatically URL-encoded
+- Complex URLs with JSON parameters are supported
+
+### Step 2: Configure Extension
+
+1. Open PopClip preferences → Extensions → Quick Navigate
+2. Set **Configuration File Path**:
+   - **Local**: `~/Documents/quicknavigate-config.json`
+   - **iCloud**: `~/Library/Mobile Documents/com~apple~CloudDocs/quicknavigate-config.json`
+3. Choose your preferred **Browser**
+4. (Optional) Enable **Skip Selection Dialog** to always use the first configuration without showing the selection menu
+
+### iCloud Sync Setup
+
+To sync your configuration across devices using iCloud:
+
+1. Save your config file to iCloud Drive:
+   ```bash
+   ~/Library/Mobile Documents/com~apple~CloudDocs/quicknavigate-config.json
+   ```
+
+2. In PopClip preferences, set the Configuration File Path to the iCloud path above
+
+3. The same configuration will be available on all your Macs with iCloud Drive enabled
+
+## Usage
+
+### Standard Usage (Show Selection Dialog)
+1. Select any text
+2. Click the Quick Navigate action in PopClip
+3. Choose from your configured navigation targets in the dialog
+4. Opens the selected URL with the selected text
+
+### Quick Mode (Skip Dialog)
+1. Enable **Skip Selection Dialog** in extension settings
+2. Select any text
+3. Click the Quick Navigate action
+4. Automatically opens the first configured URL with the selected text
+
+## Configuration Examples
+
+### Example 1: Simple Search
+```json
+{
+  "name": "Google Search",
+  "url": "https://www.google.com/search?q={text}",
+  "description": "在 Google 搜索选中的文本"
+}
+```
+
+### Example 2: Complex Grafana Query (Human Readable!)
+```json
+{
+  "name": "Grafana Logs",
+  "url": "https://your-grafana.com/explore?schemaVersion=1&panes={\"queries\":[{\"expr\":\"{app=\\\"my-app\\\"} |= `{text}`\",\"queryType\":\"range\"}],\"range\":{\"from\":\"now-7d\",\"to\":\"now\"}}",
+  "description": "搜索应用日志（最近7天）"
+}
+```
+
+**Note**: URLs are written in human-readable format with proper JSON syntax. The script handles encoding automatically.
+
+### Example 3: Internal Documentation
+```json
+{
+  "name": "Company Wiki",
+  "url": "https://wiki.company.com/search?q={text}"
+}
+```
+
+### Example 4: Translation Service
+```json
+{
+  "name": "DeepL Translate",
+  "url": "https://www.deepl.com/translator#en/zh/{text}"
+}
+```
+
+## Complete Example Configuration
+
+See `example-config.json` for a complete working example with multiple navigation targets including:
+- Google Search
+- Grafana Logs
+- GitHub Search
+- Stack Overflow
+- YouTube Search
+
+## Troubleshooting
+
+### "Configuration file not found"
+- Verify the file path is correct
+- Use absolute path or `~` for home directory
+- For iCloud, ensure iCloud Drive is enabled
+
+### "Invalid JSON format"
+- Validate your JSON using [jsonlint.com](https://jsonlint.com/)
+- Check for missing commas, brackets, or quotes
+- Ensure all required fields (`name` and `url`) are present
+
+### Extension doesn't appear
+- Verify PopClip version is 4688 or higher
+- Try reinstalling the extension
+- Check PopClip preferences to ensure the extension is enabled
+
+## Version History
+
+### 1.0 (2025-10-31)
+- Initial release
+- Basic navigation functionality
+- iCloud sync support
+- Multi-browser support
+- Option key for multiple configurations
+
+## Credits
+
+Inspired by [JSON Tailor](https://github.com/your-repo/JSONTailor) by Yimin Wang.
+
+## License
+
+Same as PopClip-Extensions repository.
+

--- a/contrib/QuickNavigate.popclipext/example-config.json
+++ b/contrib/QuickNavigate.popclipext/example-config.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "Google Search",
+    "url": "https://www.google.com/search?q={text}",
+    "description": "Search on Google"
+  },
+  {
+    "name": "GitHub Search",
+    "url": "https://github.com/search?q={text}&type=code",
+    "description": "Search code on GitHub"
+  },
+  {
+    "name": "Stack Overflow",
+    "url": "https://stackoverflow.com/search?q={text}",
+    "description": "Search technical questions on Stack Overflow"
+  },
+  {
+    "name": "YouTube Search",
+    "url": "https://www.youtube.com/results?search_query={text}",
+    "description": "Search videos on YouTube"
+  }
+]
+

--- a/contrib/QuickNavigate.popclipext/icon.svg
+++ b/contrib/QuickNavigate.popclipext/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="45" fill="#4A90E2"/>
+  <path d="M 30 50 L 60 50 L 50 35 M 60 50 L 50 65" stroke="white" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <circle cx="70" cy="50" r="8" fill="white"/>
+</svg>
+

--- a/contrib/QuickNavigate.popclipext/quicknavigate.sh
+++ b/contrib/QuickNavigate.popclipext/quicknavigate.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+
+# Get the selected text
+selected_text="$POPCLIP_TEXT"
+
+# Get options
+browser="$POPCLIP_OPTION_BROWSER"
+config_file_path="$POPCLIP_OPTION_CONFIG_FILE_PATH"
+skip_dialog="$POPCLIP_OPTION_SKIP_DIALOG"
+
+# Function to open URL in specified browser
+open_in_browser() {
+    local url="$1"
+    
+    if [ -z "$browser" ]; then
+        # No browser specified, use system default
+        open "$url"
+    else
+        # Use specified browser
+        open -a "$browser" "$url"
+    fi
+}
+
+# Function to build URL with selected text
+build_url() {
+    local url_template="$1"
+    
+    # Use Python to replace {text} with the actual text (no encoding)
+    # The browser will handle URL encoding when opening the URL
+    export URL_TEMPLATE="$url_template"
+    export SELECTED_TEXT="$selected_text"
+    
+    final_url=$(python3 <<'PYEOF'
+import os
+import sys
+
+url_template = os.environ.get('URL_TEMPLATE')
+selected_text = os.environ.get('SELECTED_TEXT')
+
+# Replace {text} or *** placeholder with the original text (no encoding)
+# The browser will handle URL encoding automatically
+final_url = url_template.replace('{text}', selected_text).replace('***', selected_text)
+
+print(final_url)
+PYEOF
+)
+    
+    echo "$final_url"
+}
+
+# Check if config file path is configured
+if [ -z "$config_file_path" ]; then
+    osascript -e 'display notification "No configuration file path specified. Please set it in Extension Options." with title "Quick Navigate" subtitle "Configuration needed"'
+    exit 1
+fi
+
+# Expand ~ to home directory
+config_file_path="${config_file_path/#\~/$HOME}"
+
+# Check if config file exists
+if [ ! -f "$config_file_path" ]; then
+    osascript -e "display notification \"Configuration file not found: $config_file_path\" with title \"Quick Navigate\" subtitle \"File not found\""
+    exit 1
+fi
+
+# Validate JSON format by trying to parse it
+if ! python3 -c "import json; json.load(open('$config_file_path'))" >/dev/null 2>&1; then
+    osascript -e 'display notification "Invalid JSON format in configuration file" with title "Quick Navigate" subtitle "Configuration error"'
+    exit 1
+fi
+
+# Check if we should show the selection dialog
+# Skip dialog if skip_dialog is true, otherwise always show dialog
+if [ "$skip_dialog" != "1" ]; then
+    # Show configuration selection menu
+    
+    # Export config file path for Python script
+    export CONFIG_FILE_PATH="$config_file_path"
+    
+    # Parse JSON and extract configuration names with numbers and descriptions
+    config_data=$(python3 <<'PYEOF'
+import json
+import sys
+import os
+try:
+    config_file = os.environ.get('CONFIG_FILE_PATH')
+    with open(config_file, 'r') as f:
+        configs = json.load(f)
+    # Create both display names (with numbers and descriptions) and original names
+    display_names = []
+    original_names = []
+    for i, config in enumerate(configs, 1):
+        if 'name' in config and 'url' in config:
+            name = config['name']
+            desc = config.get('description', '')
+            # Format: "1. Name - Description" or just "1. Name" if no description
+            if desc:
+                display_names.append(f'{i}. {name} - {desc}')
+            else:
+                display_names.append(f'{i}. {name}')
+            original_names.append(name)
+    if display_names:
+        print('DISPLAY:' + '|'.join(display_names))
+        print('ORIGINAL:' + '|'.join(original_names))
+    else:
+        print('')
+except Exception as e:
+    sys.stderr.write(f"Error: {str(e)}\n")
+    print('')
+PYEOF
+)
+    
+    if [ -z "$config_data" ]; then
+        osascript -e 'display notification "Invalid JSON format in configuration file" with title "Quick Navigate" subtitle "Configuration error"'
+        exit 1
+    fi
+    
+    # Extract display and original names
+    display_names=$(echo "$config_data" | grep "^DISPLAY:" | sed 's/^DISPLAY://')
+    original_names=$(echo "$config_data" | grep "^ORIGINAL:" | sed 's/^ORIGINAL://')
+    
+    if [ -z "$display_names" ]; then
+        osascript -e 'display notification "No valid configurations found in file" with title "Quick Navigate" subtitle "Configuration error"'
+        exit 1
+    fi
+    
+    # Convert pipe-separated names to comma-separated for AppleScript
+    config_names_list=$(echo "$display_names" | sed 's/|/", "/g')
+    
+    # Show selection dialog
+    selected_display=$(osascript <<EOF
+tell application "System Events"
+    activate
+    set configList to {"$config_names_list"}
+    set selectedConfig to choose from list configList ¬
+        with prompt "选择一个导航目标：" ¬
+        with title "Quick Navigate - 选择配置" ¬
+        default items {item 1 of configList} ¬
+        OK button name "打开" ¬
+        cancel button name "取消"
+    if selectedConfig is false then
+        return ""
+    else
+        return item 1 of selectedConfig
+    end if
+end tell
+EOF
+)
+    
+    # Check if user cancelled the dialog
+    if [ -z "$selected_display" ]; then
+        exit 0
+    fi
+    
+    # Extract the original name from the display name (remove number prefix and description)
+    # Format is "1. Name - Description", we want just "Name"
+    selected_name=$(echo "$selected_display" | sed 's/^[0-9]*\. \(.*\) - .*$/\1/')
+    
+    # If there's no description (no " - "), just remove the number prefix
+    if [ "$selected_name" = "$selected_display" ]; then
+        selected_name=$(echo "$selected_display" | sed 's/^[0-9]*\. //')
+    fi
+    
+else
+    # Skip dialog mode - use the first configuration
+    export CONFIG_FILE_PATH="$config_file_path"
+    selected_name=$(python3 <<'PYEOF'
+import json
+import sys
+import os
+try:
+    config_file = os.environ.get('CONFIG_FILE_PATH')
+    with open(config_file, 'r') as f:
+        configs = json.load(f)
+    if configs and len(configs) > 0 and 'name' in configs[0]:
+        print(configs[0]['name'])
+except Exception as e:
+    sys.stderr.write(f"Error: {str(e)}\n")
+    print('')
+PYEOF
+)
+    
+    if [ -z "$selected_name" ]; then
+        osascript -e 'display notification "No valid configuration found" with title "Quick Navigate" subtitle "Configuration error"'
+        exit 1
+    fi
+fi
+
+# Get the URL template for the selected configuration
+export CONFIG_FILE_PATH="$config_file_path"
+export SELECTED_NAME="$selected_name"
+url_template=$(python3 <<'PYEOF'
+import json
+import sys
+import os
+try:
+    config_file = os.environ.get('CONFIG_FILE_PATH')
+    selected = os.environ.get('SELECTED_NAME')
+    with open(config_file, 'r') as f:
+        configs = json.load(f)
+    for config in configs:
+        if config.get('name') == selected:
+            print(config.get('url', ''))
+            break
+except Exception as e:
+    sys.stderr.write(f"Error getting URL: {str(e)}\n")
+    print('')
+PYEOF
+)
+
+if [ -z "$url_template" ]; then
+    osascript -e 'display notification "Failed to retrieve URL template" with title "Quick Navigate Error" subtitle "Configuration error"'
+    exit 1
+fi
+
+# Build the final URL and open it
+final_url=$(build_url "$url_template")
+open_in_browser "$final_url"
+
+# Show success notification
+osascript -e "display notification \"Opening: $selected_name\" with title \"Quick Navigate\" subtitle \"Navigating...\""
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a PopClip extension to open selected text in preset URLs with a JSON-configured list, optional selection dialog, browser choice, and iCloud-friendly setup, plus docs and examples.
> 
> - **New PopClip extension: `contrib/QuickNavigate.popclipext`**
>   - `Config.yaml`: defines options for `config_file_path`, `browser`, and `skip_dialog`.
>   - `quicknavigate.sh`: core logic
>     - Loads/validates JSON config; expands `~`; error notifications.
>     - Selection dialog via AppleScript (numbered items with descriptions) or skip-first-config mode.
>     - Builds URL by replacing `{text}`/`***`; opens in specified browser; success notification.
>   - **Docs & assets**: `README.md`, `QUICKSTART.md`, `example-config.json`, `icon.svg`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b54bcdb808c2c98fab0284c2c5e0ea1d63cf52e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->